### PR TITLE
Updates github open api call

### DIFF
--- a/download-strategy.rb
+++ b/download-strategy.rb
@@ -116,6 +116,6 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDo
 
   def fetch_release_metadata
     release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
-    GitHub.open_api(release_url)
+    GitHub::API.open_rest(release_url)
   end
 end


### PR DESCRIPTION
An error when running `brew install bridge-vpn` made me do it.

Error: Calling GitHub.open_api is disabled! Use GitHub::API.open_rest instead.