### PR TITLE
Fix "unknown keyword: timeout" bug

### DIFF
--- a/download-strategy.rb
+++ b/download-strategy.rb
@@ -32,8 +32,14 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
 
   private
 
-  def _fetch(url:, resolved_url:)
-    curl_download download_url, "--header", "Authorization: token #{@github_token}", to: temporary_path
+  def _fetch(url:, resolved_url:, timeout:)
+    curl_download(
+      download_url,
+      "--header",
+      "Authorization: token #{@github_token}",
+      to: temporary_path,
+      timeout: timeout
+    )
   end
 
   def set_github_token
@@ -96,10 +102,16 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDo
 
   private
 
-  def _fetch(url:, resolved_url:)
+  def _fetch(url:, resolved_url:, timeout:)
     # HTTP request header `Accept: application/octet-stream` is required.
     # Without this, the GitHub API will respond with metadata, not binary.
-    curl_download download_url, "--header", "Accept: application/octet-stream", to: temporary_path
+    curl_download(
+      download_url,
+      "--header",
+      "Accept: application/octet-stream",
+      to: temporary_path,
+      timeout: timeout
+    )
   end
 
   def asset_id


### PR DESCRIPTION
This should resolve the issues we've seen with upgrading bridge-vpn-cli.

The error would manifest like so:

    ==> Upgrading get-bridge/tap/bridge-vpn-cli
      0.1.4 -> 0.1.5 
    ==> Downloading https://github.com/get-bridge/bridge-vpn-cli/releases/download/v0.1.5/bridge-vpn-cli_0.1.5_Darwin_x86_64.tar.gz
    Error: unknown keyword: timeout
    Please report this issue:
      https://docs.brew.sh/Troubleshooting
    /usr/local/Homebrew/Library/Taps/get-bridge/homebrew-tap/download-strategy.rb:99:in `_fetch'
    /usr/local/Homebrew/Library/Homebrew/download_strategy.rb:405:in `fetch'
    /usr/local/Homebrew/Library/Homebrew/resource.rb:142:in `fetch'   

To test this, it might be best to download the patch or raw file and then issue the command to install bridge-vpn-cli. (Remember to delete the download first if you already have it cached locally).